### PR TITLE
Suppress Resources.getResource "unstable API" warning

### DIFF
--- a/src/main/java/org/kiwiproject/eureka/EmbeddedEurekaServer.java
+++ b/src/main/java/org/kiwiproject/eureka/EmbeddedEurekaServer.java
@@ -57,7 +57,7 @@ public class EmbeddedEurekaServer {
 
         var webContext = new WebAppContext();
         webContext.setContextPath(basePath);
-        webContext.setResourceBase(Resources.getResource("webapp").toString());
+        webContext.setResourceBase(getWebappURL());
 
         buildEurekaBootstrap();
         webContext.addEventListener(registry);
@@ -67,6 +67,11 @@ public class EmbeddedEurekaServer {
         eurekaServer.setHandler(webContext);
     }
 
+    @SuppressWarnings("UnstableApiUsage")
+    private String getWebappURL() {
+        return Resources.getResource("webapp").toString();
+    }
+
     private void setupConnector() {
         connector = new ServerConnector(eurekaServer);
 
@@ -74,7 +79,7 @@ public class EmbeddedEurekaServer {
         connector.setIdleTimeout(IDLE_TIMEOUT);
 
         connector.setPort(0);
-        eurekaServer.setConnectors(new Connector[] { connector });
+        eurekaServer.setConnectors(new Connector[]{connector});
     }
 
     private void buildEurekaBootstrap() {


### PR DESCRIPTION
Guava's Resources has been there since 1.0 and for whatever reason
continues to be annotated with @Beta.