### PR TITLE
Add helper methods to EurekaServerExtension

### DIFF
--- a/src/main/java/org/kiwiproject/eureka/EmbeddedEurekaBootstrap.java
+++ b/src/main/java/org/kiwiproject/eureka/EmbeddedEurekaBootstrap.java
@@ -28,7 +28,7 @@ public class EmbeddedEurekaBootstrap extends Jersey2EurekaBootStrap {
     /**
      * Cleans out all the registered applications inside of Eureka.
      */
-    public void cleanupApps() {
+    public void clearRegisteredApps() {
         LOG.info("Clearing registry");
         serverContext.getRegistry().clearRegistry();
     }

--- a/src/main/java/org/kiwiproject/eureka/junit/EurekaServerExtension.java
+++ b/src/main/java/org/kiwiproject/eureka/junit/EurekaServerExtension.java
@@ -2,6 +2,7 @@ package org.kiwiproject.eureka.junit;
 
 import static java.util.Objects.nonNull;
 
+import com.netflix.discovery.shared.Application;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.extension.AfterAllCallback;
@@ -9,6 +10,8 @@ import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.kiwiproject.eureka.EmbeddedEurekaServer;
 import org.kiwiproject.eureka.EurekaTestHelpers;
+
+import java.util.List;
 
 /**
  * JUnit Jupiter extension that starts a local Eureka testing server before any test has run, and stops the server
@@ -74,6 +77,49 @@ public class EurekaServerExtension implements BeforeAllCallback, AfterAllCallbac
 
         // Reset static executor inside of Eureka
         EurekaTestHelpers.resetStatsMonitor();
+    }
+
+    /**
+     * Helper method to access {@link EmbeddedEurekaServer#getRegistry()}'s {@code clearRegisteredApps()}.
+     */
+    public void clearRegisteredApps() {
+        eurekaServer.getRegistry().clearRegisteredApps();
+    }
+
+    /**
+     * Helper method to access {@link EmbeddedEurekaServer#getRegistry()}'s
+     * {@code registerApplication(appName, instanceId, vipAddress, status)}.
+     */
+    public void registerApplication(String appName, String instanceId, String vipAddress, String status) {
+        eurekaServer.getRegistry().registerApplication(appName, instanceId, vipAddress, status);
+    }
+
+    /**
+     * Helper method to access {@link EmbeddedEurekaServer#getRegistry()}'s {@code registeredApplications()}.
+     */
+    public List<Application> registeredApplications() {
+        return eurekaServer.getRegistry().registeredApplications();
+    }
+
+    /**
+     * Helper method to access {@link EmbeddedEurekaServer#getRegistry()}'s {@code getRegisteredApplication(appId)}.
+     */
+    public Application getRegisteredApplication(String appId) {
+        return eurekaServer.getRegistry().getRegisteredApplication(appId);
+    }
+
+    /**
+     * Helper method to access {@link EmbeddedEurekaServer#getRegistry()}'s {@code isApplicationRegistered(appId)}.
+     */
+    public boolean isApplicationRegistered(String appId) {
+        return eurekaServer.getRegistry().isApplicationRegistered(appId);
+    }
+
+    /**
+     * Helper method to access {@link EmbeddedEurekaServer#getRegistry()}'s {@code getHeartbeatCount()}.
+     */
+    public long getHeartbeatCount() {
+        return eurekaServer.getRegistry().getHeartbeatCount();
     }
 
 }

--- a/src/main/java/org/kiwiproject/eureka/junit/EurekaServerExtension.java
+++ b/src/main/java/org/kiwiproject/eureka/junit/EurekaServerExtension.java
@@ -97,7 +97,7 @@ public class EurekaServerExtension implements BeforeAllCallback, AfterAllCallbac
     /**
      * Helper method to access {@link EmbeddedEurekaServer#getRegistry()}'s {@code registeredApplications()}.
      */
-    public List<Application> registeredApplications() {
+    public List<Application> getRegisteredApplications() {
         return eurekaServer.getRegistry().registeredApplications();
     }
 

--- a/src/test/java/org/kiwiproject/eureka/EmbeddedEurekaBootstrapTest.java
+++ b/src/test/java/org/kiwiproject/eureka/EmbeddedEurekaBootstrapTest.java
@@ -17,7 +17,7 @@ class EmbeddedEurekaBootstrapTest {
 
     @AfterEach
     void cleanupEureka() {
-        EUREKA.getEurekaServer().getRegistry().cleanupApps();
+        EUREKA.getEurekaServer().getRegistry().clearRegisteredApps();
     }
 
     @Nested

--- a/src/test/java/org/kiwiproject/eureka/junit/EurekaServerExtensionTest.java
+++ b/src/test/java/org/kiwiproject/eureka/junit/EurekaServerExtensionTest.java
@@ -107,7 +107,7 @@ class EurekaServerExtensionTest {
                         .isEqualTo(server.getRegistry().getRegisteredApplication("FOO"));
 
                 // Verify get all registered works
-                assertThat(extension.registeredApplications()).hasSameSizeAs(server.getRegistry().registeredApplications());
+                assertThat(extension.getRegisteredApplications()).hasSameSizeAs(server.getRegistry().registeredApplications());
 
                 // Verify is registered works
                 assertThat(extension.isApplicationRegistered("FOO")).isTrue();

--- a/src/test/java/org/kiwiproject/eureka/junit/EurekaServerExtensionTest.java
+++ b/src/test/java/org/kiwiproject/eureka/junit/EurekaServerExtensionTest.java
@@ -85,4 +85,38 @@ class EurekaServerExtensionTest {
         }
 
     }
+
+    @Nested
+    class UtilityMethods {
+
+        @Test
+        void shouldCallCorrectMethodsOnRegistry() {
+            var extension = new EurekaServerExtension();
+            var context = mock(ExtensionContext.class);
+
+            try {
+                extension.beforeAll(context);
+
+                var server = extension.getEurekaServer();
+
+                // Verify Register and Lookup works
+                extension.registerApplication("foo", "bar", "baz", "UP");
+                assertThat(server.getRegistry().getRegisteredApplication("FOO")).isNotNull();
+                assertThat(extension.getRegisteredApplication("FOO"))
+                        .usingRecursiveComparison()
+                        .isEqualTo(server.getRegistry().getRegisteredApplication("FOO"));
+
+                // Verify get all registered works
+                assertThat(extension.registeredApplications()).hasSameSizeAs(server.getRegistry().registeredApplications());
+
+                // Verify is registered works
+                assertThat(extension.isApplicationRegistered("FOO")).isTrue();
+
+                // Verify heart beat count works
+                assertThat(extension.getHeartbeatCount()).isEqualTo(server.getRegistry().getHeartbeatCount());
+            } finally {
+                extension.getEurekaServer().stop();
+            }
+        }
+    }
 }


### PR DESCRIPTION
* Add helper methods to access methods inside the EmbeddedEurekaBootstrap's Registry to have cleaner test code
* Renamed cleanupApps to clearRegisteredApplications

Fixes #41 