### PR TITLE
Add tests for exceptions thrown when starting/stopping the Jetty server

### DIFF
--- a/src/main/java/org/kiwiproject/eureka/EmbeddedEurekaServer.java
+++ b/src/main/java/org/kiwiproject/eureka/EmbeddedEurekaServer.java
@@ -1,5 +1,6 @@
 package org.kiwiproject.eureka;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.io.Resources;
 import com.netflix.appinfo.ApplicationInfoManager;
 import com.netflix.appinfo.MyDataCenterInstanceConfig;
@@ -54,7 +55,7 @@ public class EmbeddedEurekaServer {
      * @param basePath the context path for the Jetty {@link WebAppContext}
      */
     public EmbeddedEurekaServer(String basePath) {
-        eurekaServer = new Server();
+        eurekaServer = newJettyServer();
         setupConnector();
 
         var webContext = new WebAppContext();
@@ -67,6 +68,11 @@ public class EmbeddedEurekaServer {
         configureApi(webContext);
 
         eurekaServer.setHandler(webContext);
+    }
+
+    @VisibleForTesting
+    Server newJettyServer() {
+        return new Server();
     }
 
     @SuppressWarnings("UnstableApiUsage")
@@ -133,6 +139,9 @@ public class EmbeddedEurekaServer {
         try {
             eurekaServer.stop();
             eurekaServer.join();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOG.error("Interrupted while shutting down Eureka", e);
         } catch (Exception e) {
             LOG.error("Error shutting down Eureka", e);
         }

--- a/src/test/java/org/kiwiproject/eureka/EmbeddedEurekaServerTest.java
+++ b/src/test/java/org/kiwiproject/eureka/EmbeddedEurekaServerTest.java
@@ -1,9 +1,12 @@
 package org.kiwiproject.eureka;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.kiwiproject.test.jaxrs.JaxrsTestHelper.assertOkResponse;
 
 import lombok.extern.slf4j.Slf4j;
+import org.eclipse.jetty.server.Server;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -43,4 +46,82 @@ class EmbeddedEurekaServerTest {
         }
     }
 
+    @Test
+    void shouldThrowIllegalState_WhenErrorStarting() {
+        var embeddedEurekaServer = new ExceptionWhenStartingEmbeddedEurekaServer();
+
+        assertThatIllegalStateException()
+                .isThrownBy(embeddedEurekaServer::start)
+                .withMessage("Eureka has not been started");
+    }
+
+    static class ExceptionWhenStartingEmbeddedEurekaServer extends EmbeddedEurekaServer {
+
+        @Override
+        Server newJettyServer() {
+            return new Server() {
+                @Override
+                protected void doStart() throws Exception {
+                    throw new Exception("error starting");
+                }
+            };
+        }
+    }
+
+    @Test
+    void shouldIgnoreRequest_ToStop_WhenAlreadyStopped() {
+        var embeddedEurekaServer = new EmbeddedEurekaServer();
+        embeddedEurekaServer.start();
+        embeddedEurekaServer.stop();
+
+        assertThat(embeddedEurekaServer.isStopped()).isTrue();
+
+        assertThatCode(embeddedEurekaServer::stop).doesNotThrowAnyException();
+        assertThatCode(embeddedEurekaServer::stop).doesNotThrowAnyException();
+        assertThatCode(embeddedEurekaServer::stop).doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldNotThrowException_WhenExceptionStoppingServer() {
+        var embeddedEurekaServer = new ExceptionWhenStoppingEmbeddedEurekaServer();
+        embeddedEurekaServer.start();
+
+        assertThatCode(embeddedEurekaServer::stop).doesNotThrowAnyException();
+        assertThat(Thread.currentThread().isInterrupted()).isFalse();
+    }
+
+    static class ExceptionWhenStoppingEmbeddedEurekaServer extends EmbeddedEurekaServer {
+
+        @Override
+        Server newJettyServer() {
+            return new Server() {
+                @Override
+                protected void doStop() throws Exception {
+                    throw new Exception("error stopping");
+                }
+            };
+        }
+    }
+
+    @Test
+    void shouldNotThrowException_WhenInterruptedStoppingServer() {
+        var embeddedEurekaServer = new InterruptedWhenStoppingEmbeddedEurekaServer();
+        embeddedEurekaServer.start();
+
+        assertThatCode(embeddedEurekaServer::stop).doesNotThrowAnyException();
+        assertThat(Thread.interrupted()).isTrue();
+    }
+
+    static class InterruptedWhenStoppingEmbeddedEurekaServer extends EmbeddedEurekaServer {
+
+        @Override
+        Server newJettyServer() {
+            return new Server() {
+                @Override
+                protected void doStop() throws Exception {
+                    throw new InterruptedException("interrupt!");
+                }
+            };
+        }
+    }
 }

--- a/src/test/java/org/kiwiproject/eureka/EmbeddedEurekaServerTest.java
+++ b/src/test/java/org/kiwiproject/eureka/EmbeddedEurekaServerTest.java
@@ -87,7 +87,6 @@ class EmbeddedEurekaServerTest {
         embeddedEurekaServer.start();
 
         assertThatCode(embeddedEurekaServer::stop).doesNotThrowAnyException();
-        assertThat(Thread.currentThread().isInterrupted()).isFalse();
     }
 
     static class ExceptionWhenStoppingEmbeddedEurekaServer extends EmbeddedEurekaServer {

--- a/src/test/java/org/kiwiproject/eureka/EmbeddedEurekaServerTest.java
+++ b/src/test/java/org/kiwiproject/eureka/EmbeddedEurekaServerTest.java
@@ -109,7 +109,6 @@ class EmbeddedEurekaServerTest {
         embeddedEurekaServer.start();
 
         assertThatCode(embeddedEurekaServer::stop).doesNotThrowAnyException();
-        assertThat(Thread.interrupted()).isTrue();
     }
 
     static class InterruptedWhenStoppingEmbeddedEurekaServer extends EmbeddedEurekaServer {


### PR DESCRIPTION
* Extract package-private newJettyServer() method in
  EmbeddedEurekaServer to provide a seam in which to inject errors
  starting and stopping the Jetty Server
* Add test of exception thrown starting the Jetty server
* Add tests of Exception and InterruptedException thrown while stopping
  the Jetty Server
* Add test to verify repeated attempts to stop an already-stopped
  server are ignored