### PR TITLE
Bump kiwi and kiwi-test versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <jackson.version>[2.10.5,2.10.6)</jackson.version>
         <jetty.version>9.4.39.v20210325</jetty.version>
         <jersey.version>2.33</jersey.version>
-        <kiwi.version>0.22.0</kiwi.version>
+        <kiwi.version>0.23.0</kiwi.version>
         <servo-core.version>0.13.2</servo-core.version>
 
         <!-- Versions for provided dependencies -->
@@ -44,7 +44,7 @@
         <!-- Versions for optional dependencies -->
 
         <!-- Versions for test dependencies -->
-        <kiwi-test.version>0.18.0</kiwi-test.version>
+        <kiwi-test.version>0.19.0</kiwi-test.version>
 
         <!-- Versions for plugins -->
 


### PR DESCRIPTION
* Bump kiwi from 0.22.0 to 0.23.0
* Bump kiwi-test from 0.18.0 to 0.19.0