### PR TITLE
Update to xstream 1.4.18 (due to multiple CVEs in 1.4.17)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
         <jersey.version>2.33</jersey.version>
         <kiwi.version>1.0.0</kiwi.version>
         <servo-core.version>0.13.2</servo-core.version>
+        <xstream.version>1.4.18</xstream.version>
 
         <!-- Versions for provided dependencies -->
         <jaxb-api.version>2.3.3</jaxb-api.version>
@@ -188,6 +189,11 @@
                     <groupId>javax.servlet</groupId>
                     <artifactId>servlet-api</artifactId>
                 </exclusion>
+
+                <exclusion>
+                    <groupId>com.thoughtworks.xstream</groupId>
+                    <artifactId>xstream</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -239,6 +245,11 @@
                 <exclusion>
                     <groupId>org.glassfish.jersey.core</groupId>
                     <artifactId>jersey-client</artifactId>
+                </exclusion>
+
+                <exclusion>
+                    <groupId>com.thoughtworks.xstream</groupId>
+                    <artifactId>xstream</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -348,6 +359,12 @@
             <groupId>org.kiwiproject</groupId>
             <artifactId>kiwi</artifactId>
             <version>${kiwi.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.thoughtworks.xstream</groupId>
+            <artifactId>xstream</artifactId>
+            <version>${xstream.version}</version>
         </dependency>
 
         <!-- Provided dependencies -->


### PR DESCRIPTION
* Add xstream 1.4.18 as a top-level dependency in the POM
* Add exclusions for xstream to the eureka-client-jersey2 and
  eureka-core-jersey2 dependencies to resolve dependency convergence
  errors

Fixes #75