### PR TITLE
Remove Slf4j annotation in classes that don't log

### DIFF
--- a/src/test/java/org/kiwiproject/eureka/EmbeddedEurekaServerTest.java
+++ b/src/test/java/org/kiwiproject/eureka/EmbeddedEurekaServerTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.kiwiproject.test.jaxrs.JaxrsTestHelper.assertOkResponse;
 
-import lombok.extern.slf4j.Slf4j;
 import org.eclipse.jetty.server.Server;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -14,7 +13,6 @@ import org.kiwiproject.net.KiwiUrls;
 
 import javax.ws.rs.client.ClientBuilder;
 
-@Slf4j
 @DisplayName("EmbeddedEurekaServer")
 class EmbeddedEurekaServerTest {
 

--- a/src/test/java/org/kiwiproject/eureka/junit/EurekaServerExtensionTest.java
+++ b/src/test/java/org/kiwiproject/eureka/junit/EurekaServerExtensionTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.kiwiproject.test.jaxrs.JaxrsTestHelper.assertOkResponse;
 import static org.mockito.Mockito.mock;
 
-import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -15,7 +14,6 @@ import org.kiwiproject.net.KiwiUrls;
 
 import javax.ws.rs.client.ClientBuilder;
 
-@Slf4j
 @DisplayName("EurekaServerExtension")
 class EurekaServerExtensionTest {
 


### PR DESCRIPTION
Remove Lombok Slf4j annotation from classes that do
not actually use it to log anything. It can always be added
back later if necessary...